### PR TITLE
remove username = None on User model

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -81,7 +81,6 @@ class CustomUserManager(BaseUserManager):
 
 
 class User(AbstractUser):
-    username = None  # We will use netid as a username
     netid = models.CharField(max_length=8, unique=True)
     USERNAME_FIELD = "netid"
     REQUIRED_FIELDS = []


### PR DESCRIPTION
This prevents the username from being set to null and triggering the Not Null condition on the User model. netid is set to the username and this is set during superuser creation.