### PR TITLE
preventing js error when collectionSerach does not exist

### DIFF
--- a/core/static/js/collections.js
+++ b/core/static/js/collections.js
@@ -2,6 +2,9 @@ import { getCSRFToken } from "./utils.js";
 
 function setupCollectionSearch() {
   const collectionSearch = document.getElementById("collections-search");
+  if (!collectionSearch) {
+    return;
+  }
   collectionSearch.addEventListener("input", () => {
     const searchText = collectionSearch.value.toLowerCase();
     const landingPageList = collectionSearch.closest(".landing-page-collection-list");


### PR DESCRIPTION
This error happens when there aren't any collections available. The template doesn't load the element the EventListener is being added to since we know there isn't anything to load. To prevent this error, prevent the event listener from being added if the element is null/undefined